### PR TITLE
Enable compilation on windows

### DIFF
--- a/test/gen_casadi_test.py
+++ b/test/gen_casadi_test.py
@@ -602,9 +602,9 @@ class GenCasadiTest(unittest.TestCase):
 
     def test_caching(self):
         # Clear cache
-        shelve_file = os.path.join(TEST_DIR, 'Aircraft')
+        db_file = os.path.join(TEST_DIR, 'Aircraft')
         try:
-            os.remove(shelve_file)
+            os.remove(db_file)
         except:
             pass
 


### PR DESCRIPTION
Although this set of commits enables compilation on Windows, note that #11 is still open at time of writing. This means that loading from cache (read: DLLs) fails on Windows due to something in CasADi causing wrong .c (and therefore .dll files) to be generated.