### PR TITLE
Add support for tree lookup

### DIFF
--- a/pymola/ast.py
+++ b/pymola/ast.py
@@ -327,33 +327,6 @@ class File(Node):
         self.classes = OrderedDict()  # type: OrderedDict[str, Class]
         super().__init__(**kwargs)
 
-    def find_class(self, component_ref: ComponentRef) -> Class:
-        """
-        Find the class that a component is defined in
-        :param component_ref: component reference
-        :return: the class that contains the ref
-        """
-        name = component_ref.name
-        for c_name in self.classes.keys():
-            c = self.classes[c_name]
-            if component_ref.name in c.symbols.keys():
-                return c
-        raise KeyError(name)
-
-    def find_symbol(self, c: Class, component_ref: ComponentRef) -> Symbol:
-        """
-        Given a component ref, lookup the symbol in the given class
-        :param c: class to look in
-        :param component_ref: component reference
-        :return: the symbol
-        """
-        sym = c.symbols[component_ref.name]
-        if len(component_ref.child) > 0:
-            c = self.(sym.type)
-            return self.find_symbol(c, component_ref.child[0])
-        else:
-            return sym
-
 
 class Collection(Node):
     """

--- a/pymola/ast.py
+++ b/pymola/ast.py
@@ -338,7 +338,7 @@ class File(Node):
             c = self.classes[c_name]
             if component_ref.name in c.symbols.keys():
                 return c
-        raise KeyError('symbol {:s} not found'.format(name))
+        raise KeyError(name)
 
     def find_symbol(self, c: Class, component_ref: ComponentRef) -> Symbol:
         """
@@ -349,7 +349,7 @@ class File(Node):
         """
         sym = c.symbols[component_ref.name]
         if len(component_ref.child) > 0:
-            c = self.find_class(sym.type)
+            c = self.(sym.type)
             return self.find_symbol(c, component_ref.child[0])
         else:
             return sym
@@ -395,7 +395,7 @@ class Collection(Node):
     def extend(self, other):
         self.files.extend(other.files)
 
-    def find_class(self, component_ref: Union[ComponentRef, str], within: list = None, check_builtin_classes=False):
+    def find_class(self, component_ref: ComponentRef, within: list = None, check_builtin_classes=False):
         if check_builtin_classes:
             if component_ref.name in ["Real", "Integer", "String", "Boolean"]:
                 c = Class(name=component_ref.name)
@@ -408,10 +408,6 @@ class Collection(Node):
 
         if self._class_lookup is None:
             self._build_class_lookup()
-
-        if isinstance(component_ref, str):
-            assert component_ref.find('.') == -1
-            component_ref = ComponentRef(name=component_ref)
 
         # TODO: Support lookups starting with a dot. These are lookups in the root node (i.e. within not used).
         # Odds are that these types of lookups are not parsed yet. We would expet an empty first name, with a non-empty child.
@@ -506,3 +502,20 @@ def component_ref_to_tuple(c: ComponentRef) -> tuple:
         return (c.name, ) + component_ref_to_tuple(c.child[0])
     else:
         return (c.name, )
+
+
+def component_ref_from_string(s: str) -> ComponentRef:
+    """
+    Convert the string pointing to a component using dot notation to
+    a component reference.
+    :param s: string pointing to component using dot notation
+    :return: ComponentRef
+    """
+
+    components = s.split('.')
+    component_ref = ComponentRef(name=components[0], child=[])
+    c = component_ref
+    for component in components[1:]:
+        c.child.append(ComponentRef(name=component, child=[]))
+        c = c.child[0]
+    return component_ref

--- a/pymola/backends/casadi/api.py
+++ b/pymola/backends/casadi/api.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from typing import Dict
 import distutils.ccompiler
 import casadi as ca
 import numpy as np
@@ -79,7 +80,7 @@ class ObjectData:
         self.library = library
 
 
-def _compile_model(model_folder, model_name, compiler_options):
+def _compile_model(model_folder: str, model_name: str, compiler_options: Dict[str, str]):
     # Load folders
     tree = None
     for folder in [model_folder] + compiler_options.get('library_folders', []):
@@ -107,7 +108,7 @@ def _compile_model(model_folder, model_name, compiler_options):
 
     return model
 
-def _save_model(model_folder, model_name, model):
+def _save_model(model_folder: str, model_name: str, model: Model):
     # Compile shared libraries
     if os.name == 'posix':
         compiler_flags = ['-O2', '-fPIC']
@@ -173,7 +174,7 @@ def _save_model(model_folder, model_name, model):
 
         pickle.dump(db, f)
 
-def _load_model(model_folder, model_name, compiler_options):
+def _load_model(model_folder: str, model_name: str, compiler_options: Dict[str, str]) -> CachedModel:
     db_file = os.path.join(model_folder, model_name)
 
     if compiler_options.get('mtime_check', True):
@@ -260,7 +261,7 @@ def _load_model(model_folder, model_name, compiler_options):
     # Done
     return model
 
-def transfer_model(model_folder, model_name, compiler_options={}):
+def transfer_model(model_folder: str, model_name: str, compiler_options: Dict[str, str]={}):
     if compiler_options.get('cache', False):
         try:
             return _load_model(model_folder, model_name, compiler_options)

--- a/pymola/backends/casadi/generator.py
+++ b/pymola/backends/casadi/generator.py
@@ -68,14 +68,13 @@ class ForLoop:
 
 # noinspection PyPep8Naming,PyUnresolvedReferences
 class Generator(TreeListener):
-    def __init__(self, root: ast.Collection, class_name: str):
+    def __init__(self, cls: ast.Class):
         super(Generator, self).__init__()
         self.src = {}
         self.model = Model()
         self.nodes = {'time': self.model.time}
         self.derivative = {}
-        self.root = root
-        self.cls = root.classes[class_name]
+        self.cls = cls
         self.for_loops = []
 
     def _ast_symbols_to_variables(self, ast_symbols, differentiate=False):
@@ -324,7 +323,7 @@ class Generator(TreeListener):
         if isinstance(tree, ast.Primary):
             return int(tree.value)
         if isinstance(tree, ast.ComponentRef):
-            s = self.root.find_symbol(self.cls, tree)
+            s = self.cls.symbols[tree.name]
             assert (s.type.name == 'Integer')
             return self.get_integer(s.value)
         if isinstance(tree, ast.Expression):
@@ -347,8 +346,7 @@ class Generator(TreeListener):
                     if (len(self.for_loops) > 0) and (dep.name() == self.for_loops[-1].name):
                         vals.append(self.for_loops[-1].index_variable)
                     else:
-                        vals.append(self.get_integer(self.root.find_symbol(self.cls,
-                                                                           ast.ComponentRef(name=dep.name())).value))
+                        vals.append(self.get_integer(self.cls.symbols[dep.name()].value))
 
             # Evaluate the expression
             F = ca.Function('get_integer_{}'.format('_'.join([dep.name().replace('.', '_') for dep in deps])), deps,
@@ -423,7 +421,7 @@ class Generator(TreeListener):
                     return f.index_variable
 
         # Check ordinary symbols
-        symbol = self.root.find_symbol(self.cls, tree)
+        symbol = self.cls.symbols[tree.name]
         s = self.get_mx(symbol)
         if len(tree.indices) > 0:
             s = self.get_indexed_symbol(tree, s)
@@ -458,6 +456,6 @@ def generate(ast_tree: ast.Collection, model_name: str) -> Model:
     ast_walker = TreeWalker()
     flat_tree = flatten(ast_tree, component_ref)
     component_ref_tuple = ast.component_ref_to_tuple(component_ref)
-    casadi_gen = Generator(flat_tree, component_ref_tuple[-1])
+    casadi_gen = Generator(flat_tree.classes[component_ref_tuple[-1]])
     ast_walker.walk(casadi_gen, flat_tree)
     return casadi_gen.model

--- a/pymola/backends/casadi/generator.py
+++ b/pymola/backends/casadi/generator.py
@@ -68,14 +68,14 @@ class ForLoop:
 
 # noinspection PyPep8Naming,PyUnresolvedReferences
 class Generator(TreeListener):
-    def __init__(self, root, class_name):
+    def __init__(self, root: ast.Collection, class_name: str):
         super(Generator, self).__init__()
         self.src = {}
         self.model = Model()
         self.nodes = {'time': self.model.time}
         self.derivative = {}
         self.root = root
-        self.class_name = class_name
+        self.cls = root.classes[class_name]
         self.for_loops = []
 
     def _ast_symbols_to_variables(self, ast_symbols, differentiate=False):
@@ -324,7 +324,7 @@ class Generator(TreeListener):
         if isinstance(tree, ast.Primary):
             return int(tree.value)
         if isinstance(tree, ast.ComponentRef):
-            s = self.root.find_symbol(self.root.classes[self.class_name], tree)
+            s = self.root.find_symbol(self.cls, tree)
             assert (s.type.name == 'Integer')
             return self.get_integer(s.value)
         if isinstance(tree, ast.Expression):
@@ -347,7 +347,7 @@ class Generator(TreeListener):
                     if (len(self.for_loops) > 0) and (dep.name() == self.for_loops[-1].name):
                         vals.append(self.for_loops[-1].index_variable)
                     else:
-                        vals.append(self.get_integer(self.root.find_symbol(self.root.classes[self.class_name],
+                        vals.append(self.get_integer(self.root.find_symbol(self.cls,
                                                                            ast.ComponentRef(name=dep.name())).value))
 
             # Evaluate the expression
@@ -423,7 +423,7 @@ class Generator(TreeListener):
                     return f.index_variable
 
         # Check ordinary symbols
-        symbol = self.root.find_symbol(self.root.classes[self.class_name], tree)
+        symbol = self.root.find_symbol(self.cls, tree)
         s = self.get_mx(symbol)
         if len(tree.indices) > 0:
             s = self.get_indexed_symbol(tree, s)
@@ -448,12 +448,16 @@ class Generator(TreeListener):
         return self.src[tree]
 
 
-def generate(ast_tree, model_name):
-    # create a walker
+def generate(ast_tree: ast.Collection, model_name: str) -> Model:
+    """
+    :param ast_tree: AST to generate from
+    :param model_name: class to generate
+    :return: casadi model
+    """
+    component_ref = ast.component_ref_from_string(model_name)
     ast_walker = TreeWalker()
-
-    flat_tree = flatten(ast_tree, model_name)
-
-    casadi_gen = Generator(flat_tree, model_name)
+    flat_tree = flatten(ast_tree, component_ref)
+    component_ref_tuple = ast.component_ref_to_tuple(component_ref)
+    casadi_gen = Generator(flat_tree, component_ref_tuple[-1])
     ast_walker.walk(casadi_gen, flat_tree)
     return casadi_gen.model

--- a/pymola/backends/sympy/generator.py
+++ b/pymola/backends/sympy/generator.py
@@ -202,14 +202,14 @@ class {{tree.name}}(OdeModel):
 
 def generate(ast_tree: ast.Collection, model_name: str):
     """
-    
     :param ast_tree: AST to generate from
     :param model_name: class to generate
     :return: sympy source code for model
     """
+    component_ref = ast.component_ref_from_string(model_name)
     ast_tree_new = copy.deepcopy(ast_tree)
     ast_walker = TreeWalker()
-    flat_tree = flatten(ast_tree_new, model_name)
+    flat_tree = flatten(ast_tree_new, component_ref)
     sympy_gen = SympyGenerator()
     ast_walker.walk(sympy_gen, flat_tree)
     return sympy_gen.src[flat_tree]

--- a/pymola/tree.py
+++ b/pymola/tree.py
@@ -269,7 +269,7 @@ def flatten_class(root: ast.Collection, orig_class: ast.Class, instance_name: st
             extended_orig_class.initial_statements += flat_parent_class.initial_statements
 
             # carry out modifications
-            extended_orig_class = modify_class(root, extended_orig_class, extends.class_modification)
+            extended_orig_class = modify_class(root, extended_orig_class, extends.class_modification, orig_class.within)
 
     extended_orig_class.classes.update(orig_class.classes)
     extended_orig_class.symbols.update(orig_class.symbols)
@@ -305,7 +305,7 @@ def flatten_class(root: ast.Collection, orig_class: ast.Class, instance_name: st
 
             # If not found, do a lookup in the class tree
             if c is None:
-                c = root.find_class(sym.type)
+                c = root.find_class(sym.type, orig_class.within)
 
             if c.type == "__builtin":
                 flat_class.symbols[flat_sym.name] = flat_sym
@@ -381,7 +381,7 @@ def flatten_class(root: ast.Collection, orig_class: ast.Class, instance_name: st
     return flat_class
 
 
-def modify_class(root: ast.Collection, class_or_sym: Union[ast.Class, ast.Symbol], modification):
+def modify_class(root: ast.Collection, class_or_sym: Union[ast.Class, ast.Symbol], modification, within=[]):
     """
     Apply a modification to a class or symbol.
     :param root: root tree for looking up symbols
@@ -416,7 +416,7 @@ def modify_class(root: ast.Collection, class_or_sym: Union[ast.Class, ast.Symbol
                 orig_sym = class_or_sym.symbols[new_sym.name]
                 orig_sym.__dict__.update(new_sym.__dict__)
         elif isinstance(argument, ast.ShortClassDefinition):
-            class_or_sym.classes[argument.name] = root.find_class(argument.component)
+            class_or_sym.classes[argument.name] = root.find_class(argument.component, within)
         else:
             raise Exception('Unsupported class modification argument {}'.format(argument))
     return class_or_sym

--- a/pymola/tree.py
+++ b/pymola/tree.py
@@ -696,7 +696,7 @@ def pull_functions(root: ast.Collection, expression: ast.Expression, instance_pr
     return function_set
 
 
-def flatten(root: ast.Collection, class_name: str) -> ast.File:
+def flatten(root: ast.Collection, component_ref: ast.ComponentRef) -> ast.File:
     """
     This function takes a Collection and flattens it so that all subclasses instances
     are replaced by the their equations and symbols with name mangling
@@ -712,7 +712,7 @@ def flatten(root: ast.Collection, class_name: str) -> ast.File:
             c.within = f.within
 
     # flatten class
-    flat_class = flatten_class(root, root.find_class(class_name), '')
+    flat_class = flatten_class(root, root.find_class(component_ref), '')
 
     # expand connectors
     expand_connectors(root, flat_class)
@@ -725,6 +725,6 @@ def flatten(root: ast.Collection, class_name: str) -> ast.File:
 
     # flat file
     flat_file = ast.File()
-    flat_file.classes[class_name] = flat_class
+    flat_file.classes[flat_class.name] = flat_class
 
     return flat_file

--- a/test/TreeLookup.mo
+++ b/test/TreeLookup.mo
@@ -1,0 +1,21 @@
+within Level1.Level2.Level3;
+
+package TestPackage
+	class TestClass
+		Integer i;
+		Integer a;
+	end TestClass;
+end TestPackage;
+
+model PackageComponents
+	Level2.Level3.TestPackage.TestClass tc;
+equation
+	tc.i = 1;
+end PackageComponents;
+
+model Test
+	Level1.Level2.Level3.PackageComponents elem;
+	Integer b = 3;
+equation
+	elem.tc.a = b;
+end Test;

--- a/test/gen_casadi_test.py
+++ b/test/gen_casadi_test.py
@@ -289,17 +289,7 @@ class GenCasadiTest(unittest.TestCase):
             txt = f.read()
         ast_tree = parser.parse(txt)
 
-        # The class we want to flatten. We first have to turn it into a
-        # full-fledged ComponentRef.
-        comp_ref_tuple = ("Level1", "Level2", "Level3", "Test")
-
-        comp_ref = ast.ComponentRef(name=comp_ref_tuple[0])
-        c = comp_ref
-        for l in comp_ref_tuple[1:]:
-            c.child = [ast.ComponentRef(name=l)]
-            c = c.child[0]
-
-        casadi_model = gen_casadi.generate(ast_tree, comp_ref)
+        casadi_model = gen_casadi.generate(ast_tree, 'Level1.Level2.Level3.Test')
         ref_model = Model()
         print(casadi_model)
 

--- a/test/gen_sympy_test.py
+++ b/test/gen_sympy_test.py
@@ -12,6 +12,7 @@ import unittest
 import pymola.backends.sympy.generator as gen_sympy
 from pymola import parser
 from pymola import tree
+from pymola import ast
 
 TEST_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -52,7 +53,7 @@ class GenSympyTest(unittest.TestCase):
         with open(os.path.join(TEST_DIR, 'SpringSystem.mo'), 'r') as f:
             txt = f.read()
         ast_tree = parser.parse(txt)
-        flat_tree = tree.flatten(ast_tree, 'SpringSystem')
+        flat_tree = tree.flatten(ast_tree, ast.ComponentRef(name='SpringSystem'))
         print(flat_tree)
         text = gen_sympy.generate(ast_tree, 'SpringSystem')
         with open(os.path.join(TEST_DIR, 'generated/Spring.py'), 'w') as f:
@@ -105,7 +106,7 @@ class GenSympyTest(unittest.TestCase):
         # print(ast_tree)
 
         # noinspection PyUnusedLocal
-        flat_tree = tree.flatten(ast_tree, 'Aircraft')
+        flat_tree = tree.flatten(ast_tree, ast.ComponentRef(name='Aircraft'))
         # print(flat_tree)
 
         # noinspection PyUnusedLocal

--- a/test/parse_test.py
+++ b/test/parse_test.py
@@ -11,6 +11,7 @@ import unittest
 
 from pymola import parser
 from pymola import tree
+from pymola import ast
 
 TEST_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -132,6 +133,29 @@ class ParseTest(unittest.TestCase):
         flat_tree = tree.flatten(ast_tree, 'MainModel')
 
         self.assertEqual(flat_tree.classes['MainModel'].symbols['e.HQ.H'].min.name, "e.H_b")
+
+    def test_tree_lookup(self):
+        with open(os.path.join(TEST_DIR, 'TreeLookup.mo'), 'r') as f:
+            txt = f.read()
+        ast_tree = parser.parse(txt)
+
+        # The class we want to flatten. We first have to turn it into a
+        # full-fledged ComponentRef.
+        comp_ref_tuple = ("Level1", "Level2", "Level3", "Test")
+
+        comp_ref = ast.ComponentRef(name=comp_ref_tuple[0])
+        c = comp_ref
+        for l in comp_ref_tuple[1:]:
+            c.child = [ast.ComponentRef(name=l)]
+            c = c.child[0]
+
+        flat_tree = tree.flatten(ast_tree, comp_ref)
+
+        # NOTE: We currently do not flatten the component ref in the final
+        # tree's keys, so we use it once again to lookup the flattened class.
+        self.assertIn('elem.tc.i', flat_tree.classes[comp_ref].symbols.keys())
+        self.assertIn('elem.tc.a', flat_tree.classes[comp_ref].symbols.keys())
+        self.assertIn('b',         flat_tree.classes[comp_ref].symbols.keys())
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/parse_test.py
+++ b/test/parse_test.py
@@ -38,7 +38,7 @@ class ParseTest(unittest.TestCase):
             txt = f.read()
         ast_tree = parser.parse(txt)
         print('AST TREE\n', ast_tree)
-        flat_tree = tree.flatten(ast_tree, 'Aircraft')
+        flat_tree = tree.flatten(ast_tree, ast.ComponentRef(name='Aircraft'))
         print('AST TREE FLAT\n', flat_tree)
         self.flush()
 
@@ -48,7 +48,7 @@ class ParseTest(unittest.TestCase):
             txt = f.read()
         ast_tree = parser.parse(txt)
         print('AST TREE\n', ast_tree)
-        flat_tree = tree.flatten(ast_tree, 'BouncingBall')
+        flat_tree = tree.flatten(ast_tree, ast.ComponentRef(name='BouncingBall'))
         print(flat_tree)
         print('AST TREE FLAT\n', flat_tree)
         self.flush()
@@ -58,7 +58,7 @@ class ParseTest(unittest.TestCase):
             txt = f.read()
         ast_tree = parser.parse(txt)
         print('AST TREE\n', ast_tree)
-        flat_tree = tree.flatten(ast_tree, 'Estimator')
+        flat_tree = tree.flatten(ast_tree, ast.ComponentRef(name='Estimator'))
         print('AST TREE FLAT\n', flat_tree)
         self.flush()
 
@@ -67,7 +67,7 @@ class ParseTest(unittest.TestCase):
             txt = f.read()
         ast_tree = parser.parse(txt)
         print('AST TREE\n', ast_tree)
-        flat_tree = tree.flatten(ast_tree, 'Spring')
+        flat_tree = tree.flatten(ast_tree, ast.ComponentRef(name='Spring'))
         print('AST TREE FLAT\n', flat_tree)
         self.flush()
 
@@ -76,7 +76,7 @@ class ParseTest(unittest.TestCase):
             txt = f.read()
         ast_tree = parser.parse(txt)
         print('AST TREE\n', ast_tree)
-        flat_tree = tree.flatten(ast_tree, 'SpringSystem')
+        flat_tree = tree.flatten(ast_tree, ast.ComponentRef(name='SpringSystem'))
         print('AST TREE FLAT\n', flat_tree)
         self.flush()
 
@@ -85,7 +85,7 @@ class ParseTest(unittest.TestCase):
             txt = f.read()
         ast_tree = parser.parse(txt)
         print('AST TREE\n', ast_tree)
-        flat_tree = tree.flatten(ast_tree, 'DuplicateState')
+        flat_tree = tree.flatten(ast_tree, ast.ComponentRef(name='DuplicateState'))
         print('AST TREE FLAT\n', flat_tree)
         self.flush()
 
@@ -105,7 +105,7 @@ class ParseTest(unittest.TestCase):
         with open(os.path.join(TEST_DIR, 'InheritanceInstantiation.mo'), 'r') as f:
             txt = f.read()
         ast_tree = parser.parse(txt)
-        flat_tree = tree.flatten(ast_tree, 'C2')
+        flat_tree = tree.flatten(ast_tree, ast.ComponentRef(name='C2'))
 
         self.assertEqual(flat_tree.classes['C2'].symbols['bcomp1.b'].value.value, 3.0)
 
@@ -113,7 +113,7 @@ class ParseTest(unittest.TestCase):
         with open(os.path.join(TEST_DIR, 'NestedClasses.mo'), 'r') as f:
             txt = f.read()
         ast_tree = parser.parse(txt)
-        flat_tree = tree.flatten(ast_tree, 'C2')
+        flat_tree = tree.flatten(ast_tree, ast.ComponentRef(name='C2'))
 
         self.assertEqual(flat_tree.classes['C2'].symbols['v1'].nominal.value, 1000.0)
         self.assertEqual(flat_tree.classes['C2'].symbols['v2'].nominal.value, 1000.0)
@@ -122,7 +122,7 @@ class ParseTest(unittest.TestCase):
         with open(os.path.join(TEST_DIR, 'Inheritance.mo'), 'r') as f:
             txt = f.read()
         ast_tree = parser.parse(txt)
-        flat_tree = tree.flatten(ast_tree, 'Sub')
+        flat_tree = tree.flatten(ast_tree, ast.ComponentRef(name='Sub'))
 
         self.assertEqual(flat_tree.classes['Sub'].symbols['x'].max.value, 30.0)
 
@@ -130,7 +130,7 @@ class ParseTest(unittest.TestCase):
         with open(os.path.join(TEST_DIR, 'ExtendsModification.mo'), 'r') as f:
             txt = f.read()
         ast_tree = parser.parse(txt)
-        flat_tree = tree.flatten(ast_tree, 'MainModel')
+        flat_tree = tree.flatten(ast_tree, ast.ComponentRef(name='MainModel'))
 
         self.assertEqual(flat_tree.classes['MainModel'].symbols['e.HQ.H'].min.name, "e.H_b")
 
@@ -141,21 +141,16 @@ class ParseTest(unittest.TestCase):
 
         # The class we want to flatten. We first have to turn it into a
         # full-fledged ComponentRef.
-        comp_ref_tuple = ("Level1", "Level2", "Level3", "Test")
-
-        comp_ref = ast.ComponentRef(name=comp_ref_tuple[0])
-        c = comp_ref
-        for l in comp_ref_tuple[1:]:
-            c.child = [ast.ComponentRef(name=l)]
-            c = c.child[0]
+        class_name = 'Level1.Level2.Level3.Test'
+        comp_ref = ast.component_ref_from_string(class_name)
 
         flat_tree = tree.flatten(ast_tree, comp_ref)
 
         # NOTE: We currently do not flatten the component ref in the final
         # tree's keys, so we use it once again to lookup the flattened class.
-        self.assertIn('elem.tc.i', flat_tree.classes[comp_ref].symbols.keys())
-        self.assertIn('elem.tc.a', flat_tree.classes[comp_ref].symbols.keys())
-        self.assertIn('b',         flat_tree.classes[comp_ref].symbols.keys())
+        self.assertIn('elem.tc.i', flat_tree.classes['Test'].symbols.keys())
+        self.assertIn('elem.tc.a', flat_tree.classes['Test'].symbols.keys())
+        self.assertIn('b',         flat_tree.classes['Test'].symbols.keys())
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Note that the lookup is based on the presence of "within" statements.
With an actual tree instead of Collection/File/Class/Symbol differences,
the lookup process will be better. The current implementation likely
does not handle (nested) local classes/packages in a single file well.