### PR TITLE
Treat functions as a classes

### DIFF
--- a/pymola/backends/casadi/generator.py
+++ b/pymola/backends/casadi/generator.py
@@ -627,7 +627,7 @@ def generate(ast_tree: ast.Collection, model_name: str) -> Model:
     component_ref = ast.ComponentRef.from_string(model_name)
     ast_walker = TreeWalker()
     flat_tree = flatten(ast_tree, component_ref)
-    component_ref_tuple = component_ref.to_tuple(component_ref)
+    component_ref_tuple = component_ref.to_tuple()
     casadi_gen = Generator(flat_tree, component_ref_tuple[-1])
     ast_walker.walk(casadi_gen, flat_tree)
     return casadi_gen.model

--- a/pymola/tree.py
+++ b/pymola/tree.py
@@ -787,4 +787,12 @@ def flatten(root: ast.Collection, component_ref: ast.ComponentRef) -> ast.File:
     flat_file = ast.File()
     flat_file.classes[flat_class.name] = flat_class
 
+    # pull functions to the top level,
+    # putting them prior to the model class so that they are visited
+    # first by the tree walker.
+    functions_and_classes = flat_class.functions
+    functions_and_classes.update(flat_file.classes)
+    flat_file.classes = functions_and_classes
+    flat_class.functions = OrderedDict()
+
     return flat_file

--- a/test/parse_test.py
+++ b/test/parse_test.py
@@ -163,25 +163,25 @@ class ParseTest(unittest.TestCase):
         flat_tree = tree.flatten(ast_tree, comp_ref)
 
         # Check if all referenced functions are pulled in
-        self.assertIn('Level1.Level2.Level3.f', flat_tree.classes['Function5'].functions)
-        self.assertIn('Level1.Level2.Level3.TestPackage.times2', flat_tree.classes['Function5'].functions)
-        self.assertIn('Level1.Level2.Level3.TestPackage.square', flat_tree.classes['Function5'].functions)
-        self.assertNotIn('Level1.Level2.Level3.TestPackage.not_called', flat_tree.classes['Function5'].functions)
+        self.assertIn('Level1.Level2.Level3.f', flat_tree.classes)
+        self.assertIn('Level1.Level2.Level3.TestPackage.times2', flat_tree.classes)
+        self.assertIn('Level1.Level2.Level3.TestPackage.square', flat_tree.classes)
+        self.assertNotIn('Level1.Level2.Level3.TestPackage.not_called', flat_tree.classes)
 
         # Check if the classes in the flattened tree have the right type
         self.assertEqual(flat_tree.classes['Function5'].type, 'model')
 
-        self.assertEqual(flat_tree.classes['Function5'].functions['Level1.Level2.Level3.f'].type, 'function')
-        self.assertEqual(flat_tree.classes['Function5'].functions['Level1.Level2.Level3.TestPackage.times2'].type, 'function')
-        self.assertEqual(flat_tree.classes['Function5'].functions['Level1.Level2.Level3.TestPackage.square'].type, 'function')
+        self.assertEqual(flat_tree.classes['Level1.Level2.Level3.f'].type, 'function')
+        self.assertEqual(flat_tree.classes['Level1.Level2.Level3.TestPackage.times2'].type, 'function')
+        self.assertEqual(flat_tree.classes['Level1.Level2.Level3.TestPackage.square'].type, 'function')
 
         # Check whether input/output information of functions comes along properly
-        func_t2 = flat_tree.classes['Function5'].functions['Level1.Level2.Level3.TestPackage.times2']
+        func_t2 = flat_tree.classes['Level1.Level2.Level3.TestPackage.times2']
         self.assertIn("input", func_t2.symbols['x'].prefixes)
         self.assertIn("output", func_t2.symbols['y'].prefixes)
 
         # Check if built-in function call statement comes along properly
-        func_f = flat_tree.classes['Function5'].functions['Level1.Level2.Level3.f']
+        func_f = flat_tree.classes['Level1.Level2.Level3.f']
         self.assertEqual(func_f.statements[0].right.operator, '*')
         # Check if user-specified function call statement comes along properly
         self.assertEqual(func_f.statements[0].right.operands[0].operator,


### PR DESCRIPTION
Previously, we would require that the tree walker visit functions prior to classes, so that expressions contained in functions had been compiled to MX prior to their invocation.