### PR TITLE
Add lookup of constants

### DIFF
--- a/pymola/ast.py
+++ b/pymola/ast.py
@@ -440,6 +440,17 @@ class Class(Node):
 
         return c
 
+    def find_symbol(self, component_ref: ComponentRef) -> Symbol:
+        if component_ref.child:
+            t = component_ref.to_tuple()
+            class_cref, sym_name = t[:-1], t[-1]
+            node = self.find_class(ComponentRef.from_tuple(class_cref))
+        else:
+            sym_name = component_ref.name
+            node = self
+        return node.symbols[sym_name]
+
+
     def full_reference(self):
         names = []
 

--- a/pymola/tree.py
+++ b/pymola/tree.py
@@ -704,6 +704,51 @@ def apply_symbol_modifications(node: ast.Node) -> None:
     w.walk(SymbolModificationApplier(node), node)
 
 
+class ConstantReferenceApplier(TreeListener):
+    """
+    This walker applies all references to constants. For each referenced
+    constant it makes a symbol in the passed in InstanceClass class_, with the
+    flattened component reference to the constant as the symbol's name.
+    """
+
+    def __init__(self, class_: ast.InstanceClass):
+        self.classes = []
+
+        # We cannot directly mutate the dictionary while we are looping over
+        # it, so instead we store symbol updates here.
+        self.extra_symbols = OrderedDict()
+
+        super().__init__()
+
+    def enterComponentRef(self, tree: ast.ComponentRef):
+        # If it is not a nested comonent reference, we do not have to do
+        # anyhing as the symbol we look for would already be in the current
+        # class
+        if tree.child:
+            try:
+                s = self.classes[-1].find_symbol(tree)
+                if 'constant' in s.prefixes:
+                    self.extra_symbols[str(tree)] = s
+            except (KeyError, ast.ClassNotFoundError, ast.FoundElementaryClassError):
+                pass
+
+    def enterInstanceClass(self, tree: ast.InstanceClass):
+        self.classes.append(tree)
+
+    def exitInstanceClass(self, tree: ast.InstanceClass):
+        c = self.classes.pop()
+        c.symbols.update(self.extra_symbols)
+        self.extra_symbols = OrderedDict()
+
+    def enterClass(self, tree: ast.InstanceClass):
+        assert False, "All classes should have been replaced by instance classes."
+
+
+def apply_constant_references(class_: ast.InstanceClass) -> None:
+    w = TreeWalker()
+    w.walk(ConstantReferenceApplier(class_), class_)
+
+
 def flatten_class(orig_class: ast.Class) -> ast.Class:
     # First we build a tree of the to-be-flattened class, with all symbol
     # types expanded to classes as well. Modifications are shifted/passed
@@ -722,6 +767,9 @@ def flatten_class(orig_class: ast.Class) -> ast.Class:
     apply_symbol_modifications(instance_tree)
 
     # At this point there are no modifications left, on classes or symbols of whatever kind.
+
+    # Pull references to constants
+    apply_constant_references(instance_tree)
 
     # Finally we flatten all symbols.
     flat_class = flatten_symbols(instance_tree)

--- a/test/ConstantReferences.mo
+++ b/test/ConstantReferences.mo
@@ -1,0 +1,27 @@
+package P0
+  constant Real p[2] = {1, 2};
+end P0;
+
+package P1
+  constant Real p = 1;
+end P1;
+
+package P2
+  constant Real p = 2;
+end P2;
+
+model a
+  replaceable package m = P1;
+end a;
+
+model b
+  package m2 = P2;
+  extends a(redeclare package m = m2);
+  Real x;
+  parameter Real y = m.p;
+  parameter Real z = P0.p[0];
+  Real w;
+equation
+  x = m.p;
+  w = m.p * 2.0;
+end b;

--- a/test/ConstantReferences.mo
+++ b/test/ConstantReferences.mo
@@ -10,6 +10,14 @@ package P2
   constant Real p = 2;
 end P2;
 
+model M1
+  constant Real f = 3;
+end M1;
+
+model M2
+  constant M1 m;
+end M2;
+
 model a
   replaceable package m = P1;
 end a;
@@ -21,7 +29,9 @@ model b
   parameter Real y = m.p;
   parameter Real z = P0.p[0];
   Real w;
+  Real g;
 equation
+  g = M2.m.f;
   x = m.p;
   w = m.p * 2.0;
 end b;

--- a/test/parse_test.py
+++ b/test/parse_test.py
@@ -258,6 +258,17 @@ class ParseTest(unittest.TestCase):
 
         self.assertEqual(flat_tree.classes['M'].symbols['at.m'].value.value, 0.0)
 
+    def test_constant_references(self):
+        with open(os.path.join(TEST_DIR, 'ConstantReferences.mo'), 'r') as f:
+            txt = f.read()
+        ast_tree = parser.parse(txt)
+
+        class_name = 'b'
+        comp_ref = ast.ComponentRef.from_string(class_name)
+
+        flat_tree = tree.flatten(ast_tree, comp_ref)
+
+        self.assertEqual(flat_tree.classes['b'].symbols['m.p'].value.value, 2.0)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/parse_test.py
+++ b/test/parse_test.py
@@ -269,6 +269,7 @@ class ParseTest(unittest.TestCase):
         flat_tree = tree.flatten(ast_tree, comp_ref)
 
         self.assertEqual(flat_tree.classes['b'].symbols['m.p'].value.value, 2.0)
+        self.assertEqual(flat_tree.classes['b'].symbols['M2.m.f'].value.value, 3.0)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
One can make references to constants outside the current class. These constants may even be nested inside symbols, as long as the symbols themselves are also constant.

To support this, we drag the referenced constant symbols in the to-be-flattened class as additional symbols (i.e. we do _not_ replace the constant reference with its primary value). 

Support for constant references with array indices is iffy, and will probably fail in many cases.