### PR TITLE
Avoid excessive copying of instance tree

### DIFF
--- a/pymola/tree.py
+++ b/pymola/tree.py
@@ -486,8 +486,10 @@ def flatten_symbols(class_: ast.InstanceClass, instance_name='') -> ast.Class:
             # we keep connectors in the class hierarchy, as we may refer to them further
             # up using connect() clauses
             if sym.type.type == 'connector':
-                # TODO: Should we flatten sym.type (e.g. because it is faster)?
-                flat_sym.__connector_type = sym.type
+                # We flatten sym.type here to avoid later deepcopy()
+                # statements copying the entire instance tree due to
+                # references to parent and/or root.
+                flat_sym.__connector_type = flatten_class(sym.type)
                 flat_class.symbols[flat_sym.name] = flat_sym
 
                 # TODO: Do we need the symbol type after this?


### PR DESCRIPTION
Every connect statement had an instance node reference. When expressions
were copied (i.e. in component ref flattening), it would copy the entire
tree again due to the references to parent/root.