### PR TITLE
workaround for alias relation

### DIFF
--- a/pymola/backends/casadi/model.py
+++ b/pymola/backends/casadi/model.py
@@ -393,11 +393,13 @@ class Model:
                             other_state = None
 
                         if alg_state is not None:
+                            # Get canonical name and sign of other state
+                            canonical_other_state, sign = alias_rel.canonical_signed(other_state.name())
                             # Add alias
-                            if eq.is_op(ca.OP_SUB):
-                                alias_rel.add(other_state.name(), alg_state.name())
+                            if eq.is_op(ca.OP_SUB) ^ (sign < 0):
+                                alias_rel.add(canonical_other_state, alg_state.name())
                             else:
-                                alias_rel.add(other_state.name(), '-' + alg_state.name())
+                                alias_rel.add(canonical_other_state, '-' + alg_state.name())
 
                             # Skip this equation
                             continue


### PR DESCRIPTION
AliasRelation is not very intelligent when it comes to detecting matches between positive and negative states:
```
In [1]: from rtctools._internal.alias_tools import AliasRelation
In [2]: a = AliasRelation()
In [3]: a.add('a', '-b'); a.add('b', 'c')
In [4]: list(a)
Out[4]: [('a', ['-b']), ('b', ['c'])]
```
When iterating over `alias_rel` to eliminate alias variables, `b` would get eliminated as an alias of `a`, even though it was still the canonical variable for `c`.

This pull request makes sure the first parameter to add() is a canonical var. This helps alias_rel to be constructed correctly.

It might be nice if AliasRelation.add() were a bit smarter, or if there were a AliasRelation.flatten() method to call.
 