### PR TITLE
ensure alias relation detects all matches when using add()

### DIFF
--- a/pymola/backends/casadi/alias_relation.py
+++ b/pymola/backends/casadi/alias_relation.py
@@ -124,7 +124,11 @@ class AliasRelation:
             return '-' + v
 
     def aliases(self, a):
-        return self._aliases.get(a, OrderedSet([a]))
+        if a[0] == '-':
+            a = self.__toggle_sign(a)
+            return OrderedSet([self.__toggle_sign(v) for v in self._aliases.get(a, OrderedSet([a]))])
+        else:
+            return self._aliases.get(a, OrderedSet([a]))
 
     def canonical_signed(self, a):
         if a[0] == '-':

--- a/pymola/backends/casadi/alias_relation.py
+++ b/pymola/backends/casadi/alias_relation.py
@@ -102,7 +102,8 @@ class AliasRelation:
         # Update _aliases so that keys are always positive
         inverted_aliases = OrderedSet([self.__toggle_sign(v) for v in aliases])
         for v in aliases:
-            if v[0] == '-':
+            if self.__is_negative(v):
+                # If v is negative, we make it positive and store the inverse alias set
                 self._aliases[self.__toggle_sign(v)] = inverted_aliases
             else:
                 self._aliases[v] = aliases
@@ -110,7 +111,7 @@ class AliasRelation:
         # Update _canonical_variables with new canonical var and remove old ones
         self._canonical_variables.add(aliases[0])
         for v in aliases[1:]:
-            if v[0] == '-':
+            if self.__is_negative(v):
                 v = self.__toggle_sign(v)
             try:
                 self._canonical_variables.remove(v)
@@ -118,28 +119,31 @@ class AliasRelation:
                 pass
 
     def __toggle_sign(self, v):
-        if v[0] == '-':
+        if self.__is_negative(v):
             return v[1:]
         else:
             return '-' + v
 
+    def __is_negative(self, v):
+        return True if v[0] == '-' else False
+
     def aliases(self, a):
-        if a[0] == '-':
+        if self.__is_negative(a):
             a = self.__toggle_sign(a)
             return OrderedSet([self.__toggle_sign(v) for v in self._aliases.get(a, OrderedSet([a]))])
         else:
             return self._aliases.get(a, OrderedSet([a]))
 
     def canonical_signed(self, a):
-        if a[0] == '-':
+        if self.__is_negative(a):
             top_alias = self.aliases(self.__toggle_sign(a))[0]
         else:
             top_alias = self.aliases(a)[0]
 
-        if top_alias[0] == '-':
-            return top_alias[1:], 1 if a[0] == '-' else -1
+        if self.__is_negative(top_alias):
+            return top_alias[1:], 1 if self.__is_negative(a) else -1
         else:
-            return top_alias, -1 if a[0] == '-' else 1
+            return top_alias, -1 if self.__is_negative(a) else 1
 
     @property
     def canonical_variables(self):

--- a/pymola/backends/casadi/alias_relation.py
+++ b/pymola/backends/casadi/alias_relation.py
@@ -99,16 +99,15 @@ class AliasRelation:
 
     def flatten(self):
         for v in self.canonical_variables:
-            vt = self.__toggle(v)
-            for al in self.aliases(v):
-                self.add(vt, self.__toggle(al))
+            vt = self.__toggle_sign(v)
+            for a in self.aliases(v):
+                self.add(vt, self.__toggle_sign(a))
 
         for v in self.canonical_variables:
             if v[0] == '-':
-                del self._aliases[v]
                 self._canonical_variables.remove(v)
 
-    def __toggle(self, v):
+    def __toggle_sign(self, v):
         if v[0] == '-':
             return v[1:]
         else:
@@ -121,10 +120,7 @@ class AliasRelation:
         if a in self._aliases:
             return self.aliases(a)[0], 1
         else:
-            if a[0] == '-':
-                b = a[1:]
-            else:
-                b = '-' + a
+            b = self.__toggle_sign(a)
             if b in self._aliases:
                 return self.aliases(b)[0], -1
             else:

--- a/pymola/backends/casadi/alias_relation.py
+++ b/pymola/backends/casadi/alias_relation.py
@@ -97,6 +97,23 @@ class AliasRelation:
             except KeyError:
                 pass
 
+    def flatten(self):
+        for v in self.canonical_variables:
+            vt = self.__toggle(v)
+            for al in self.aliases(v):
+                self.add(vt, self.__toggle(al))
+
+        for v in self.canonical_variables:
+            if v[0] == '-':
+                del self._aliases[v]
+                self._canonical_variables.remove(v)
+
+    def __toggle(self, v):
+        if v[0] == '-':
+            return v[1:]
+        else:
+            return '-' + v
+
     def aliases(self, a):
         return self._aliases.get(a, OrderedSet([a]))
 

--- a/pymola/backends/casadi/model.py
+++ b/pymola/backends/casadi/model.py
@@ -397,11 +397,6 @@ class Model:
                             # To keep equations balanced, we make sure that we don't drop
                             # equations unless we are also eliminating a variable.
 
-                            # For now, if alg_state is already aliased, we keep the equation.
-                            if alg_state.name() != alias_rel.canonical_signed(alg_state.name())[0]:
-                                reduced_equations.append(eq)
-                                continue
-
                             # Add alias
                             if eq.is_op(ca.OP_SUB):
                                 alias_rel.add(other_state.name(), alg_state.name())

--- a/pymola/backends/casadi/model.py
+++ b/pymola/backends/casadi/model.py
@@ -393,6 +393,15 @@ class Model:
                             other_state = None
 
                         if alg_state is not None:
+                            # We found an alg_state to alias
+                            # To keep equations balanced, we make sure that we don't drop
+                            # equations unless we are also eliminating a variable.
+
+                            # For now, if alg_state is already aliased, we keep the equation.
+                            if alg_state.name() != alias_rel.canonical_signed(alg_state.name())[0]:
+                                reduced_equations.append(eq)
+                                continue
+
                             # Add alias
                             if eq.is_op(ca.OP_SUB):
                                 alias_rel.add(other_state.name(), alg_state.name())

--- a/pymola/backends/casadi/model.py
+++ b/pymola/backends/casadi/model.py
@@ -393,11 +393,13 @@ class Model:
                             other_state = None
 
                         if alg_state is not None:
+                            # Get canonical name and sign of other state
+                            canonical_other_state, sign = alias_rel.canonical_signed(other_state.name())
                             # Add alias
-                            if eq.is_op(ca.OP_SUB):
-                                alias_rel.add(other_state.name(), alg_state.name())
+                            if eq.is_op(ca.OP_SUB) ^ (sign < 0):
+                                alias_rel.add(canonical_other_state, alg_state.name())
                             else:
-                                alias_rel.add(other_state.name(), '-' + alg_state.name())
+                                alias_rel.add(canonical_other_state, '-' + alg_state.name())
 
                             # Skip this equation
                             continue

--- a/pymola/backends/casadi/model.py
+++ b/pymola/backends/casadi/model.py
@@ -393,13 +393,11 @@ class Model:
                             other_state = None
 
                         if alg_state is not None:
-                            # Get canonical name and sign of other state
-                            canonical_other_state, sign = alias_rel.canonical_signed(other_state.name())
                             # Add alias
-                            if eq.is_op(ca.OP_SUB) ^ (sign < 0):
-                                alias_rel.add(canonical_other_state, alg_state.name())
+                            if eq.is_op(ca.OP_SUB):
+                                alias_rel.add(other_state.name(), alg_state.name())
                             else:
-                                alias_rel.add(canonical_other_state, '-' + alg_state.name())
+                                alias_rel.add(other_state.name(), '-' + alg_state.name())
 
                             # Skip this equation
                             continue

--- a/pymola/backends/casadi/model.py
+++ b/pymola/backends/casadi/model.py
@@ -414,9 +414,6 @@ class Model:
                 # Keep this equation
                 reduced_equations.append(eq)
 
-            # Flatten model
-            alias_rel.flatten()
-
             # Eliminate alias variables
             variables, values = [], []
             for canonical, aliases in alias_rel:

--- a/pymola/backends/casadi/model.py
+++ b/pymola/backends/casadi/model.py
@@ -405,6 +405,9 @@ class Model:
                 # Keep this equation
                 reduced_equations.append(eq)
 
+            # Flatten model
+            alias_rel.flatten()
+
             # Eliminate alias variables
             variables, values = [], []
             for canonical, aliases in alias_rel:

--- a/test/gen_casadi_test.py
+++ b/test/gen_casadi_test.py
@@ -13,9 +13,11 @@ import casadi as ca
 import numpy as np
 
 import pymola.backends.casadi.generator as gen_casadi
+from pymola.backends.casadi.alias_relation import AliasRelation
 from pymola.backends.casadi.model import Model, Variable
 from pymola.backends.casadi.api import transfer_model, CachedModel
 from pymola import parser, ast
+
 
 TEST_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -1243,6 +1245,14 @@ class GenCasadiTest(unittest.TestCase):
 
         self.assert_model_equivalent_numeric(ref_model, casadi_model)
 
+
+    def test_alias_relation(self):
+        a = AliasRelation()
+        self.assertEqual(a.canonical_signed('-a'), ('a', -1))
+        a.add('a', '-b')
+        a.add('b', 'c')
+        a.add('d', '-b')
+        self.assertEqual(list(a), [('d', ['a', '-b', '-c'])])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
AliasRelation is not very intelligent when it comes to detecting matches between positive and negative states:
```
In [1]: from rtctools._internal.alias_tools import AliasRelation
In [2]: a = AliasRelation()
In [3]: a.add('a', '-b'); a.add('b', 'c')
In [4]: list(a)
Out[4]: [('a', ['-b']), ('b', ['c'])]
```
When iterating over `alias_rel` to eliminate alias variables, `b` would get eliminated as an alias of `a`, even though it was still the canonical variable for `c`.

This pull request gives AliasRelation a flatten() method to call. flatten() matches positive and negative symbols and simplifies the alias relation.
 