### PR TITLE
Keep output variable names in alias reduction

### DIFF
--- a/pymola/backends/casadi/api.py
+++ b/pymola/backends/casadi/api.py
@@ -172,8 +172,10 @@ def _save_model(model_folder: str, model_name: str, model: Model):
         db['library_os'] = os.name
 
         # Describe variables per category
-        for key in ['states', 'der_states', 'alg_states', 'inputs', 'outputs', 'parameters', 'constants']:
+        for key in ['states', 'der_states', 'alg_states', 'inputs', 'parameters', 'constants']:
             db[key] = [e.to_dict() for e in getattr(model, key)]
+
+        db['outputs'] = model.outputs
 
         db['delayed_states'] = model.delayed_states
 
@@ -225,7 +227,7 @@ def _load_model(model_folder: str, model_name: str, compiler_options: Dict[str, 
                 variable_dict[variable.symbol.name()] = variable
 
         model.der_states = [Variable.from_dict(d) for d in db['der_states']]
-        model.outputs = [variable_dict[v['name']] for v in db['outputs']]
+        model.outputs = db['outputs']
         model.delayed_states = db['delayed_states']
 
         # Evaluate variable metadata:

--- a/pymola/backends/casadi/generator.py
+++ b/pymola/backends/casadi/generator.py
@@ -147,8 +147,9 @@ class Generator(TreeListener):
         # We extend the input list, as it is already populated with delayed states.
         self.model.inputs.extend(self._ast_symbols_to_variables(inputs))
 
-        # The outputs are a subset of the states.
-        self.model.outputs = [v for v in itertools.chain(self.model.states, self.model.alg_states) if 'output' in v.prefixes]
+        # The outputs are a list of strings of state names. Specifying
+        # multiple aliases of the same state is allowed.
+        self.model.outputs = [v.symbol.name() for v in itertools.chain(self.model.states, self.model.alg_states) if 'output' in v.prefixes]
 
         def discard_empty(l):
             return list(filter(lambda x: not ca.MX(x).is_empty(), l))

--- a/pymola/backends/casadi/model.py
+++ b/pymola/backends/casadi/model.py
@@ -368,7 +368,6 @@ class Model:
             der_states = OrderedDict([(s.symbol.name(), s) for s in self.der_states])
             alg_states = OrderedDict([(s.symbol.name(), s) for s in self.alg_states])
             inputs = OrderedDict([(s.symbol.name(), s) for s in self.inputs])
-            outputs = OrderedDict([(s.symbol.name(), s) for s in self.outputs])
 
             all_states = OrderedDict()
             all_states.update(states)
@@ -475,8 +474,6 @@ class Model:
                     fixed = ca.fmax(fixed, alias_state.fixed)
 
                     del all_states[alias]
-                    if alias in outputs:
-                        outputs[alias].symbol = sign * canonical_state.symbol
 
                 canonical_state.aliases = aliases
                 canonical_state.python_type = python_type
@@ -490,7 +487,6 @@ class Model:
             self.der_states = [v for k, v in all_states.items() if k in der_states]
             self.alg_states = [v for k, v in all_states.items() if k in alg_states]
             self.inputs = [v for k, v in all_states.items() if k in inputs]
-            self.outputs = list(outputs.values())
             self.equations = reduced_equations
 
             if len(self.equations) > 0:


### PR DESCRIPTION
Instead of applying alias reduction to output states, we instead keep a
list of output names. Multiple output names can map (knowingly or
unknowling) to the same state, should they be aliases.

Closes #51