### PR TITLE
Fix check for already defined CasADi functions

### DIFF
--- a/pymola/backends/casadi/generator.py
+++ b/pymola/backends/casadi/generator.py
@@ -633,7 +633,7 @@ class Generator(TreeListener):
 
         output_expr = ca.substitute([values[output] for output in outputs], tmp, [values[t] for t in tmp])
         function = ca.Function(tree.name, inputs, output_expr)
-        self.functions[tree.name] = function
+        self.functions[function_name] = function
 
         return function
 

--- a/test/DoubleFunctionCall.mo
+++ b/test/DoubleFunctionCall.mo
@@ -1,0 +1,42 @@
+// Test to make sure that multiple calls a function do not result in more than
+// one instance of the function itself.
+package A
+  function CircleProperties
+    input Real radius;
+    output Real circumference;
+    output Real area;
+    output Real d;
+    output Real e;
+    output Real s1;
+    output Real s2;
+    output Real ignored;
+  protected
+    Real diameter := radius*2;
+  algorithm
+    circumference := 3.14159*diameter;
+    area := 3.14159*radius^2;
+    if area > 10 then
+      d := 1;
+      e := 10;
+    else
+      d := 2;
+      e := area;
+    end if;
+    s1 := 1;
+    s2 := 0;
+    for i in 1:3 loop
+      s1 := 2 * s1;
+      s2 := s2 + 1;
+    end for;
+    ignored := 12;
+  end CircleProperties;
+end A;
+
+model FunctionCall
+    Real r;
+    output Real c, a, d, e, S1, S2;
+equation
+    (c, a, d, e, S1, S2) = A.CircleProperties(r);
+    (c, a, d, e, S1, S2) = A.CircleProperties(r);
+end FunctionCall;
+

--- a/test/gen_casadi_test.py
+++ b/test/gen_casadi_test.py
@@ -475,6 +475,20 @@ class GenCasadiTest(unittest.TestCase):
 
         self.assert_model_equivalent_numeric(ref_model, casadi_model)
 
+    def test_double_function_call(self):
+        with open(os.path.join(TEST_DIR, 'DoubleFunctionCall.mo'), 'r') as f:
+            txt = f.read()
+        ast_tree = parser.parse(txt)
+        casadi_model = gen_casadi.generate(ast_tree, 'FunctionCall')
+        print("FunctionCall", casadi_model)
+        ref_model = Model()
+
+        # Check that both instances of the function call refer to the same node in the tree
+        func_a = casadi_model.equations[0].dep(1).dep(0).dep(0).dep(0).getFunction().__hash__()
+        func_b = casadi_model.equations[1].dep(1).dep(0).dep(0).dep(0).getFunction().__hash__()
+
+        self.assertEqual(func_a, func_b)
+
     def test_forloop(self):
         with open(os.path.join(TEST_DIR, 'ForLoop.mo'), 'r') as f:
             txt = f.read()


### PR DESCRIPTION
If the function called was nested in some package (e.g. a_package.func),
multiple calls to it would result in multiple instances of it.

Closes #55