### PR TITLE
Handle value assignments like modifications

### DIFF
--- a/pymola/parser.py
+++ b/pymola/parser.py
@@ -595,16 +595,15 @@ class ASTListener(ModelicaListener):
             for mod in self.ast[ctx.modification()]:
                 if isinstance(mod, ast.ClassModification):
                     sym.class_modification = mod
-                elif isinstance(mod, ast.Primary):
-                    sym.value = mod
-                elif isinstance(mod, ast.Array):
-                    sym.value = mod
-                elif isinstance(mod, ast.Expression):
-                    sym.value = mod
-                elif isinstance(mod, ast.ComponentRef):
-                    sym.value = mod
                 else:
-                    raise IOError('unhandled modification type', type(mod))
+                    # Assignment of value, which we turn into a modification here.
+                    sym_mod = ast.ClassModification()
+                    vmod_arg = ast.ClassModificationArgument()
+                    vmod_arg.value = ast.ElementModification()
+                    vmod_arg.value.component = ast.ComponentRef(name="value")
+                    vmod_arg.value.modifications = [mod]
+                    sym_mod.arguments.append(vmod_arg)
+                    sym.class_modification = sym_mod
 
     def exitElement_modification(self, ctx):
         component = self.ast[ctx.component_reference()]

--- a/pymola/tree.py
+++ b/pymola/tree.py
@@ -369,10 +369,6 @@ def build_instance_tree(orig_class: Union[ast.Class, ast.InstanceClass], modific
                         # modification with attribute name "value" that we
                         # pick up later in modify_symbol()
 
-                        # TODO: Is it also possible for users to say
-                        # x(nominal=1.0, value=3.0), and that x = 3.0 is
-                        # just a shorthand for x(value=3.0)
-
                         # TODO: Figure out if it's easier to directly do this
                         # in the parser.
                         vmod_arg = ast.ClassModificationArgument()


### PR DESCRIPTION
This fixes the case when we instantiate a custom type that inherits from a
built-in type.

Closes #57