### PR TITLE
Fix alias detection for inputs

### DIFF
--- a/pymola/backends/casadi/model.py
+++ b/pymola/backends/casadi/model.py
@@ -482,8 +482,8 @@ class Model:
 
             self.states = [v for k, v in all_states.items() if k in states]
             self.der_states = [v for k, v in all_states.items() if k in der_states]
-            self.alg_states = [v for k, v in all_states.items() if k in alg_states]
-            self.inputs = [v for k, v in all_states.items() if k in inputs]
+            self.alg_states = [v for k, v in all_states.items() if k in alg_states and set(v.aliases) <= alg_states.keys()]
+            self.inputs = [v for k, v in all_states.items() if k in inputs or any((x in inputs for x in v.aliases))]
             self.equations = reduced_equations
 
             if len(self.equations) > 0:


### PR DESCRIPTION
States could end up in the wrong group, when an alias of a symbol (and
not the key it was stored with) was defined as an input.

To properly detect an input, we therefore now check to see if _any_ of
the symbol's aliases is an input (and vice versa for alg_states).