### PR TITLE
Log message when simplification steps complete

### DIFF
--- a/pymola/backends/casadi/model.py
+++ b/pymola/backends/casadi/model.py
@@ -530,6 +530,8 @@ class Model:
             if len(self.initial_equations) > 0:
                 self.initial_equations = ca.matrix_expand(self.initial_equations)
 
+        logger.info("Finished model simplification")
+
     @property
     def dae_residual_function(self):
         return ca.Function('dae_residual', [self.time, ca.veccat(*self._symbols(self.states)), ca.veccat(*self._symbols(self.der_states)),


### PR DESCRIPTION
Especially when larger models are being simplified, it helps knowing
when the simplifications steps are complete. Otherwise one might be lead
to think that the last simplification step is taking a lot of time.