### PR TITLE
check symbolic equations for eliminable_variable_expression

### DIFF
--- a/pymola/backends/casadi/model.py
+++ b/pymola/backends/casadi/model.py
@@ -175,6 +175,15 @@ class Model:
 
             reduced_equations = []
             for eq in self.equations:
+                if eq.is_symbolic() and eq.name() in alg_states:
+                    constant = alg_states.pop(eq.name())
+                    constant.value = 0.0
+
+                    self.constants.append(constant)
+
+                    # Skip this equation
+                    continue
+
                 if eq.n_dep() == 2 and (eq.is_op(ca.OP_SUB) or eq.is_op(ca.OP_ADD)):
                     if eq.dep(0).is_symbolic() and eq.dep(0).name() in alg_states and eq.dep(1).is_constant():
                         variable = eq.dep(0)
@@ -270,6 +279,7 @@ class Model:
                     del alg_states[eq.name()]
                     # Skip this equation
                     continue
+
                 if eq.n_dep() == 2 and (eq.is_op(ca.OP_SUB) or eq.is_op(ca.OP_ADD)):
                     if eq.dep(0).is_symbolic() and eq.dep(0).name() in alg_states and p.match(eq.dep(0).name()):
                         variable = eq.dep(0)

--- a/pymola/backends/casadi/model.py
+++ b/pymola/backends/casadi/model.py
@@ -264,6 +264,11 @@ class Model:
 
             reduced_equations = []
             for eq in self.equations:
+                if eq.is_symbolic() and eq.name() in alg_states and p.match(eq.name()):
+                    variables.append(eq)
+                    values.append(0.0)
+                    # Skip this equation
+                    continue
                 if eq.n_dep() == 2 and (eq.is_op(ca.OP_SUB) or eq.is_op(ca.OP_ADD)):
                     if eq.dep(0).is_symbolic() and eq.dep(0).name() in alg_states and p.match(eq.dep(0).name()):
                         variable = eq.dep(0)

--- a/pymola/backends/casadi/model.py
+++ b/pymola/backends/casadi/model.py
@@ -267,6 +267,7 @@ class Model:
                 if eq.is_symbolic() and eq.name() in alg_states and p.match(eq.name()):
                     variables.append(eq)
                     values.append(0.0)
+                    del alg_states[eq.name()]
                     # Skip this equation
                     continue
                 if eq.n_dep() == 2 and (eq.is_op(ca.OP_SUB) or eq.is_op(ca.OP_ADD)):


### PR DESCRIPTION
There are still more trivial optimizations that can be done to catch up with RTC2.0/jModelica.
To date:
- [X] Detect and eliminate single-symbol equations that match the `eliminable_variable_expression`
- [ ] Detect and alias(à la jModelica) or eliminate(even better :) single-symbol equations
- [ ] Not sure the extent that RTC2.0/jModelica did this, but there are a ton of states that could be eliminated in Rijnland if we wanted to eliminate states. (not sure if we should do this in RTC-Tools 2.2 or pymola)